### PR TITLE
fix: Generate release changelog

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -57,6 +57,7 @@ jobs:
       - name: create tags
         id: create-tags
         run: |
+          # the tag will look similar to: 0.102.1-0.1.0
           echo 'TAGS=${{ steps.load-envs.outputs.OTEL_VERSION }}-${{ steps.prepare-envs.outputs.SEMVER }}' >> "$GITHUB_OUTPUT"
           echo 'CURRENT_TAG=${{ github.ref_name }}' >> "$GITHUB_OUTPUT"
           

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -12,9 +12,6 @@ env:
 
   BUILD_MODE: release
 
-permissions:
-  contents: write
-
 jobs:
 
   envs:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -12,6 +12,9 @@ env:
 
   BUILD_MODE: release
 
+permissions:
+  contents: write
+
 jobs:
 
   envs:
@@ -76,6 +79,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -36,7 +36,7 @@ jobs:
         id: prepare-envs
         run: |
           # just stripping the leading `v` from the tag
-          SEMVER=${ echo ${{ github.ref_name }} | sed 's/^v//' }
+          SEMVER=$( echo ${{ github.ref_name }} | sed 's/^v//' )
           {
           # this creates a multiline string with the envs. 
           # Everything between `build-args<<BUILD_ARGS` and BUILD_ARGS will be content of the build-args variable.
@@ -57,6 +57,7 @@ jobs:
       - name: create tags
         id: create-tags
         run: |
+          # the final tag will look like 0.102.1-0.1.1
           echo 'TAGS="${{ steps.load-envs.outputs.OTEL_VERSION }}-${{ steps.prepare-envs.outputs.SEMVER }}"' >> "$GITHUB_OUTPUT"
           echo 'CURRENT_TAG="${{ github.ref_name }}"' >> "$GITHUB_OUTPUT"
           

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -57,18 +57,18 @@ jobs:
       - name: create tags
         id: create-tags
         run: |
-          # the final tag will look like 0.102.1-0.1.1
-          echo 'TAGS="${{ steps.load-envs.outputs.OTEL_VERSION }}-${{ steps.prepare-envs.outputs.SEMVER }}"' >> "$GITHUB_OUTPUT"
-          echo 'CURRENT_TAG="${{ github.ref_name }}"' >> "$GITHUB_OUTPUT"
+          echo 'TAGS=${{ steps.load-envs.outputs.OTEL_VERSION }}-${{ steps.prepare-envs.outputs.SEMVER }}' >> "$GITHUB_OUTPUT"
+          echo 'CURRENT_TAG=${{ github.ref_name }}' >> "$GITHUB_OUTPUT"
           
           # join all tags with the new tag in one list. Inject our new version in the list. Sort the list and get the line prior to the new tag
+          PREFIX=v
           previous_version=$((git for-each-ref --sort=creatordate --format '%(refname)' refs/tags && echo refs/tags/v${{ steps.prepare-envs.outputs.SEMVER }}) \
           | grep -E "^refs/tags/${PREFIX}[0-9]+\.[0-9]+\.[0-9]+$" \
           | grep -E "[0-9]+\.[0-9]+\.[0-9]+" -o \
           | sort -t "." -k1,1n -k2,2n -k3,3n \
           | grep -B 1 ${{ steps.prepare-envs.outputs.SEMVER }} | head -1)
           
-          echo 'PREVIOUS_TAG="v${previous_version}"' >> "$GITHUB_OUTPUT"
+          echo "PREVIOUS_TAG=v${previous_version}" >> "$GITHUB_OUTPUT"
 
   build-image:
     needs: envs

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -3,7 +3,7 @@ name: Tag Release
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 env:
 
   # BUILD_MODE can be either `PR` or `release`. `PR` uses the code from the current branch using `replace` directive in the builder-config.yaml
@@ -21,22 +21,32 @@ jobs:
       tags: ${{ steps.create-tags.outputs.tags }}
       otel-version: ${{ steps.load-envs.outputs.OTEL_VERSION }}
       otel-contrib-version: ${{ steps.load-envs.outputs.OTEL_CONTRIB_VERSION }}
-      pr-tag: ${{ steps.create-tags.outputs.PR_TAG }}
-      push-tag: ${{ steps.create-tags.outputs.PUSH_TAG }}
+      current-tag: ${{ steps.create-tags.outputs.CURRENT_TAG }}
+      previous-tag: ${{ steps.create-tags.outputs.PREVIOUS_TAG }}
+      semver: ${{ steps.prepare-envs.outputs.SEMVER }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        # fetch-depth: 0 is required to fetch all tags
+        with:
+          fetch-depth: 0
 
       - name: prepare envs
         id: prepare-envs
         run: |
+          # just stripping the leading `v` from the tag
+          SEMVER=${ echo ${{ github.ref_name }} | sed 's/^v//' }
           {
+          # this creates a multiline string with the envs. 
+          # Everything between `build-args<<BUILD_ARGS` and BUILD_ARGS will be content of the build-args variable.
           echo 'build-args<<BUILD_ARGS'
           echo "BUILD_MODE=${{ env.BUILD_MODE }}"
-          echo "KYMA_OCC_VERSION=${{ github.ref_name }}"
+          echo "KYMA_OCC_VERSION=$SEMVER"
           cat otel-collector/envs
           echo BUILD_ARGS 
+          
+          echo "SEMVER=$SEMVER"
           } >> "$GITHUB_OUTPUT"
 
       - name: load envs into output
@@ -44,13 +54,20 @@ jobs:
         run: |
           cat otel-collector/envs >> "$GITHUB_OUTPUT"
 
-      - name: print env context
-        run: echo "${{ steps.prepare-envs.outputs.build-args }}"
-
       - name: create tags
         id: create-tags
         run: |
-          echo 'TAGS="${{ steps.load-envs.outputs.OTEL_VERSION }}-${{ github.ref_name }}"' >> "$GITHUB_OUTPUT"
+          echo 'TAGS="${{ steps.load-envs.outputs.OTEL_VERSION }}-${{ steps.prepare-envs.outputs.SEMVER }}"' >> "$GITHUB_OUTPUT"
+          echo 'CURRENT_TAG="${{ github.ref_name }}"' >> "$GITHUB_OUTPUT"
+          
+          # join all tags with the new tag in one list. Inject our new version in the list. Sort the list and get the line prior to the new tag
+          previous_version=$((git for-each-ref --sort=creatordate --format '%(refname)' refs/tags && echo refs/tags/v${{ steps.prepare-envs.outputs.SEMVER }}) \
+          | grep -E "^refs/tags/${PREFIX}[0-9]+\.[0-9]+\.[0-9]+$" \
+          | grep -E "[0-9]+\.[0-9]+\.[0-9]+" -o \
+          | sort -t "." -k1,1n -k2,2n -k3,3n \
+          | grep -B 1 ${{ steps.prepare-envs.outputs.SEMVER }} | head -1)
+          
+          echo 'PREVIOUS_TAG="v${previous_version}"' >> "$GITHUB_OUTPUT"
 
   build-image:
     needs: envs
@@ -72,7 +89,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [ build-image ]
+    needs: [ build-image, envs ]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -89,5 +106,6 @@ jobs:
           version: '~> v2'
           args: release --clean
         env:
-          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+          GORELEASER_CURRENT_TAG: ${{ needs.envs.outputs.current-tag }}
+          GORELEASER_PREVIOUS_TAG: ${{ needs.envs.outputs.previous-tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -89,4 +89,5 @@ jobs:
           version: '~> v2'
           args: release --clean
         env:
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- extract the semver from the tag, ignore all other monorepo tags (not supported by goreleaser-free)
- calculate previous tag 

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The PR has a milestone set.
- [ ] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
