### PR TITLE
feat: Make module status conditions metric optional

### DIFF
--- a/receiver/kymastatsreceiver/kyma_scraper.go
+++ b/receiver/kymastatsreceiver/kyma_scraper.go
@@ -108,8 +108,8 @@ func (ks *kymaScraper) collectModuleStats(ctx context.Context) ([]moduleStats, e
 			}
 
 			res = append(res, *stats)
-
 			// Take only the first valid module custom resource
+
 			break
 		}
 	}
@@ -134,24 +134,33 @@ func (ks *kymaScraper) unstructuredToStats(module unstructured.Unstructured) (*m
 		return nil, &fieldNotFoundError{"state"}
 	}
 
-	unstructuredConds, found, err := unstructured.NestedSlice(status, "conditions")
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		return nil, &fieldNotFoundError{"conditions"}
-	}
-
 	stats := &moduleStats{
 		state:     state,
 		namespace: module.GetNamespace(),
 		kind:      module.GetKind(),
 	}
 
+	unstructuredConds, found, err := unstructured.NestedSlice(status, "conditions")
+	if err != nil || !found {
+		ks.logger.Error("Error converting unstructured module to stats, no module condition found",
+			zap.Error(err),
+			zap.String("name", module.GetName()),
+			zap.String("namespace", module.GetNamespace()),
+			zap.String("kind", module.GetKind()),
+		)
+		return stats, nil
+	}
+
 	for _, unstructuredCond := range unstructuredConds {
 		cond, err := ks.unstructuredToCondition(unstructuredCond)
 		if err != nil {
-			return nil, err
+			ks.logger.Error("Error converting unstructured module to stats, condition not supported",
+				zap.Error(err),
+				zap.String("name", module.GetName()),
+				zap.String("namespace", module.GetNamespace()),
+				zap.String("kind", module.GetKind()),
+			)
+			continue
 		}
 		stats.conditions = append(stats.conditions, *cond)
 	}

--- a/receiver/kymastatsreceiver/kyma_scraper.go
+++ b/receiver/kymastatsreceiver/kyma_scraper.go
@@ -109,7 +109,6 @@ func (ks *kymaScraper) collectModuleStats(ctx context.Context) ([]moduleStats, e
 
 			res = append(res, *stats)
 			// Take only the first valid module custom resource
-
 			break
 		}
 	}
@@ -141,8 +140,17 @@ func (ks *kymaScraper) unstructuredToStats(module unstructured.Unstructured) (*m
 	}
 
 	unstructuredConds, found, err := unstructured.NestedSlice(status, "conditions")
-	if err != nil || !found {
-		ks.logger.Error("Error converting unstructured module to stats, no module condition found",
+	if err != nil {
+		ks.logger.Warn("Failed to retrieve conditions: conditions are not a slice",
+			zap.Error(err),
+			zap.String("name", module.GetName()),
+			zap.String("namespace", module.GetNamespace()),
+			zap.String("kind", module.GetKind()),
+		)
+		return stats, nil
+	}
+	if !found {
+		ks.logger.Warn("Failed to retrieve conditions: conditions not found",
 			zap.Error(err),
 			zap.String("name", module.GetName()),
 			zap.String("namespace", module.GetNamespace()),

--- a/receiver/kymastatsreceiver/kyma_scraper_test.go
+++ b/receiver/kymastatsreceiver/kyma_scraper_test.go
@@ -41,7 +41,7 @@ func TestScrape(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 
-	telemetry := newUnstructuredObject("Telemetry", "default")
+	telemetry := newUnstructuredObject("Telemetry")
 	unstructured.SetNestedMap(telemetry, map[string]interface{}{
 		"state": "Ready",
 		"conditions": []interface{}{
@@ -53,7 +53,7 @@ func TestScrape(t *testing.T) {
 		},
 	}, "status")
 
-	istio := newUnstructuredObject("Istio", "default")
+	istio := newUnstructuredObject("Istio")
 	unstructured.SetNestedMap(istio, map[string]interface{}{
 		"state": "Warning",
 		"conditions": []interface{}{
@@ -115,7 +115,7 @@ func TestScrape_CantPullResource(t *testing.T) {
 	scheme := runtime.NewScheme()
 
 	client := fake.NewSimpleDynamicClient(scheme, &unstructured.Unstructured{
-		Object: newUnstructuredObject("MyKymaModule", "default"),
+		Object: newUnstructuredObject("MyKymaModule"),
 	})
 
 	client.PrependReactor("list", "mykymamodules", func(action clienttesting.Action) (bool, runtime.Object, error) {
@@ -292,7 +292,7 @@ func TestScrape_HandlesInvalidResourceGracefully(t *testing.T) {
 				},
 			}
 			scheme := runtime.NewScheme()
-			obj := newUnstructuredObject("MyKymaModule", "default")
+			obj := newUnstructuredObject("MyKymaModule")
 			if tt.status != nil {
 				unstructured.SetNestedField(obj, tt.status, "status")
 			}
@@ -314,13 +314,13 @@ func TestScrape_HandlesInvalidResourceGracefully(t *testing.T) {
 	}
 }
 
-func newUnstructuredObject(kind, name string) map[string]interface{} {
+func newUnstructuredObject(kind string) map[string]interface{} {
 	return map[string]interface{}{
 		"apiVersion": moduleGroup + "/" + moduleVersion,
 		"kind":       kind,
 		"metadata": map[string]interface{}{
 			"namespace": moduleNamespace,
-			"name":      name,
+			"name":      "default",
 		},
 	}
 }

--- a/receiver/kymastatsreceiver/kyma_scraper_test.go
+++ b/receiver/kymastatsreceiver/kyma_scraper_test.go
@@ -148,9 +148,8 @@ func TestScrape_HandlesInvalidResourceGracefully(t *testing.T) {
 			name: "no status",
 		},
 		{
-			name:               "status not a map",
-			status:             "not a map",
-			expectedDataPoints: 0,
+			name:   "status not a map",
+			status: "not a map",
 		},
 		{
 			name: "no state",
@@ -163,14 +162,12 @@ func TestScrape_HandlesInvalidResourceGracefully(t *testing.T) {
 					},
 				},
 			},
-			expectedDataPoints: 0,
 		},
 		{
 			name: "state not a string",
 			status: map[string]interface{}{
 				"state": map[string]interface{}{},
 			},
-			expectedDataPoints: 0,
 		},
 		{
 			name: "no conditions",


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Not all Kyma modules define conditions attribute type of `metav1.condition` but a state attribute, the metric receiver will emit for such modules at least `kyma.module.status.state` metric and skip emitting `kyma.module.status.conditions` metric

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/opentelemetry-collector-components/issues/15

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The PR has a milestone set.
- [x] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [x] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
