### PR TITLE
feat: Config validation in singletonreceivercreator

### DIFF
--- a/receiver/kymastatsreceiver/config_test.go
+++ b/receiver/kymastatsreceiver/config_test.go
@@ -43,7 +43,6 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			id: component.NewIDWithName(metadata.Type, "kubeconfig"),
 			expected: &Config{

--- a/receiver/singletonreceivercreator/README.md
+++ b/receiver/singletonreceivercreator/README.md
@@ -39,8 +39,8 @@ The configuration consists of two parts:
 ### Leader Election Configuration
 | configuration       | description                                                                     | default value      |
 |---------------------|---------------------------------------------------------------------------------|--------------------|
-| **lease_name**      | The name of the lease object.                                                   | singleton-receiver |
-| **lease_namespace** | The namespace of the lease object.                                              | default            |
+| **lease_name**      | The name of the lease object.                                                   | none (required)    |
+| **lease_namespace** | The namespace of the lease object.                                              | none (required)    |
 | **lease_duration**  | The duration of the lease.                                                      | 15s                |
 | **renew_deadline**  | The deadline for renewing the lease. It should be less than the lease duration. | 10s                |
 | **retry_period**    | The period for retrying the leader election.                                    | 2s                 |

--- a/receiver/singletonreceivercreator/factory.go
+++ b/receiver/singletonreceivercreator/factory.go
@@ -27,11 +27,9 @@ func createDefaultConfig() component.Config {
 			AuthType: k8sconfig.AuthTypeServiceAccount,
 		},
 		leaderElectionConfig: leaderElectionConfig{
-			leaseName:      "singleton-receiver",
-			leaseNamespace: "default",
-			leaseDuration:  defaultLeaseDuration,
-			renewDuration:  defaultRenewDeadline,
-			retryPeriod:    defaultRetryPeriod,
+			leaseDuration: defaultLeaseDuration,
+			renewDuration: defaultRenewDeadline,
+			retryPeriod:   defaultRetryPeriod,
 		},
 		subreceiverConfig: receiverConfig{},
 	}

--- a/receiver/singletonreceivercreator/factory_test.go
+++ b/receiver/singletonreceivercreator/factory_test.go
@@ -48,11 +48,9 @@ func TestNewFactory(t *testing.T) {
 						AuthType: "serviceAccount",
 					},
 					leaderElectionConfig: leaderElectionConfig{
-						leaseName:      "singleton-receiver",
-						leaseNamespace: "default",
-						leaseDuration:  defaultLeaseDuration,
-						renewDuration:  defaultRenewDeadline,
-						retryPeriod:    defaultRetryPeriod,
+						leaseDuration: defaultLeaseDuration,
+						renewDuration: defaultRenewDeadline,
+						retryPeriod:   defaultRetryPeriod,
 					},
 					subreceiverConfig: receiverConfig{},
 				}

--- a/receiver/singletonreceivercreator/testdata/config.yaml
+++ b/receiver/singletonreceivercreator/testdata/config.yaml
@@ -18,21 +18,21 @@ singleton_receiver_creator/zero_lease_duration:
   leader_election:
     lease_name: foo
     lease_namespace: bar
-    lease_duration: 0 
+    lease_duration: 0s
   receiver:
     dummy:
 singleton_receiver_creator/zero_renew_deadline:
   leader_election:
     lease_name: foo
     lease_namespace: bar
-    renew_deadline: 0
+    renew_deadline: 0s
   receiver:
     dummy:
-singleton_receiver_creator/zero_renew_period:
+singleton_receiver_creator/zero_retry_period:
   leader_election:
     lease_name: foo
     lease_namespace: bar
-    retry_period: 0 
+    retry_period: 0s
   receiver:
     dummy:
 singleton_receiver_creator/complex_subreceiver:

--- a/receiver/singletonreceivercreator/testdata/config.yaml
+++ b/receiver/singletonreceivercreator/testdata/config.yaml
@@ -54,7 +54,7 @@ singleton_receiver_creator/complex_subreceiver:
       resource_attributes:
         container.id:
           enabled: false
-singleton_receiver_creator/authtype_kubeconfig:
+singleton_receiver_creator/auth_type_kubeconfig:
   auth_type: kubeConfig
   leader_election:
     lease_name: foo

--- a/receiver/singletonreceivercreator/testdata/config.yaml
+++ b/receiver/singletonreceivercreator/testdata/config.yaml
@@ -1,9 +1,41 @@
-singleton_receiver_creator/check-default-values:
+singleton_receiver_creator/default:
+  leader_election:
+    lease_name: foo
+    lease_namespace: bar
   receiver:
-    otlp:
-      protocols:
-        grpc:
-singleton_receiver_creator/check-all-values:
+    dummy:
+singleton_receiver_creator/missing_name:
+  leader_election:
+    lease_namespace: bar
+  receiver:
+    dummy:
+singleton_receiver_creator/missing_namespace:
+  leader_election:
+    lease_name: foo
+  receiver:
+    dummy:
+singleton_receiver_creator/zero_lease_duration:
+  leader_election:
+    lease_name: foo
+    lease_namespace: bar
+    lease_duration: 0 
+  receiver:
+    dummy:
+singleton_receiver_creator/zero_renew_deadline:
+  leader_election:
+    lease_name: foo
+    lease_namespace: bar
+    renew_deadline: 0
+  receiver:
+    dummy:
+singleton_receiver_creator/zero_renew_period:
+  leader_election:
+    lease_name: foo
+    lease_namespace: bar
+    retry_period: 0 
+  receiver:
+    dummy:
+singleton_receiver_creator/complex_subreceiver:
   auth_type: serviceAccount
   leader_election:
     lease_name: foo
@@ -22,7 +54,7 @@ singleton_receiver_creator/check-all-values:
       resource_attributes:
         container.id:
           enabled: false
-singleton_receiver_creator/check-kubeconfig-authtype:
+singleton_receiver_creator/authtype_kubeconfig:
   auth_type: kubeConfig
   leader_election:
     lease_name: foo


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Make `lease_name` and `lease_namespace` required
- Validate that time durations > 0
- Add test cases

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/opentelemetry-collector-components/issues/90

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] If the change is user-facing, the documentation has been adjusted.
- [x] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
