### PR TITLE
feat: Rename module to resources and look for all resources

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,7 @@ linters:
   # Depreacted linters
     - gomnd
     - execinquery
+    - exportloopref
   # Linters to be enabled after fixing the issues
     - intrange
     - cyclop
@@ -55,7 +56,7 @@ linters-settings:
       - pkg: "k8s.io/apimachinery/pkg/apis/meta/v1"
         alias: metav1
       - pkg: "k8s.io/client-go/dynamic/fake"
-        alias: dynamicfake 
+        alias: dynamicfake
       - pkg: "k8s.io/client-go/testing"
         alias: clienttesting
 

--- a/receiver/kymastatsreceiver/README.md
+++ b/receiver/kymastatsreceiver/README.md
@@ -6,7 +6,7 @@
 | stability   | alpha: metrics             |
 | Code Owners | kyma-project/observability |
 
-The Kyma Stats Receiver pulls Kyma modules from the API server, creates status metrics, and sends them down the metric pipeline for further processing.
+The Kyma Stats Receiver pulls Kyma resources from the API server, creates status metrics, and sends them down the metric pipeline for further processing.
 
 ## Metrics
 
@@ -18,7 +18,7 @@ The following settings are required:
 
 - `auth_type` (default = `serviceAccount`): Specifies the authentication method for accessing the Kubernetes API server.
    Options include `none` (no authentication), `serviceAccount` (uses the default service account token assigned to the Pod), or `kubeConfig` (uses credentials from `~/.kube/config`).
-- `modules`: A list of API group-version-resources of Kyma modules. For each group-version-resource, the status metrics are generated for the first resource instance found.
+- `resources`: A list of API group-version-resources of Kyma resources. Status metrics are generated for each group-version-resource.
 
 The following settings are optional:
 
@@ -33,18 +33,18 @@ Example:
     auth_type: seviceAccount
     collection_interval: 30s
     metrics:
-      kyma.module.status.state:
+      kyma.resource.status.state:
         enabled: true
-      kyma.module.status.conditions:
+      kyma.resource.status.conditions:
         enabled: true
-    modules:
+    resources:
     - group: operator.kyma-project.io
       version: v1alpha1
       resource: telemetries
     resource_attributes:
       k8s.namespace.name:
         enabled: true
-      kyma.module.name:
+      kyma.resource.name:
         enabled: true
 ```
 

--- a/receiver/kymastatsreceiver/README.md
+++ b/receiver/kymastatsreceiver/README.md
@@ -44,7 +44,7 @@ Example:
     resource_attributes:
       k8s.namespace.name:
         enabled: true
-      kyma.resource.name:
+      k8s.resource.name:
         enabled: true
 ```
 

--- a/receiver/kymastatsreceiver/config.go
+++ b/receiver/kymastatsreceiver/config.go
@@ -15,19 +15,19 @@ type Config struct {
 	k8sconfig.APIConfig            `mapstructure:",squash"`
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
 	metadata.MetricsBuilderConfig  `mapstructure:",squash"`
-	Modules                        []ModuleConfig `mapstructure:"modules"`
+	Resources                      []ResourceConfig `mapstructure:"resources"`
 
 	// Used for unit testing only
 	makeDynamicClient func() (dynamic.Interface, error)
 }
 
-type ModuleConfig struct {
+type ResourceConfig struct {
 	Group    string `mapstructure:"group"`
 	Version  string `mapstructure:"version"`
 	Resource string `mapstructure:"resource"`
 }
 
-var errEmptyModules = errors.New("empty modules")
+var errEmptyResources = errors.New("empty resources")
 
 func (cfg *Config) Validate() error {
 	if err := cfg.APIConfig.Validate(); err != nil {
@@ -38,8 +38,8 @@ func (cfg *Config) Validate() error {
 		return err
 	}
 
-	if len(cfg.Modules) == 0 {
-		return errEmptyModules
+	if len(cfg.Resources) == 0 {
+		return errEmptyResources
 	}
 
 	return nil

--- a/receiver/kymastatsreceiver/config_test.go
+++ b/receiver/kymastatsreceiver/config_test.go
@@ -37,7 +37,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				ControllerConfig:     scraperhelper.ControllerConfig{CollectionInterval: duration, InitialDelay: delay},
 				MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
-				Modules: []ModuleConfig{
+				Resources: []ResourceConfig{
 					{
 						Group:    "operator.kyma-project.io",
 						Version:  "v1alpha1",
@@ -55,7 +55,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				ControllerConfig:     scraperhelper.ControllerConfig{CollectionInterval: 30 * time.Second, InitialDelay: delay},
 				MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
-				Modules: []ModuleConfig{
+				Resources: []ResourceConfig{
 					{
 						Group:    "operator.kyma-project.io",
 						Version:  "v1alpha1",
@@ -72,7 +72,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				ControllerConfig:     scraperhelper.ControllerConfig{CollectionInterval: 10 * time.Second, InitialDelay: delay},
 				MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
-				Modules: []ModuleConfig{
+				Resources: []ResourceConfig{
 					{
 						Group:    "operator.kyma-project.io",
 						Version:  "v1alpha1",
@@ -97,7 +97,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				ControllerConfig:     scraperhelper.ControllerConfig{CollectionInterval: duration, InitialDelay: delay},
 				MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
-				Modules: []ModuleConfig{
+				Resources: []ResourceConfig{
 					{
 						Group:    "operator.kyma-project.io",
 						Version:  "v1alpha1",
@@ -107,7 +107,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
-			id:        component.NewIDWithName(metadata.Type, "nomodulegroups"),
+			id:        component.NewIDWithName(metadata.Type, "noresourcegroups"),
 			expectErr: true,
 		},
 	}

--- a/receiver/kymastatsreceiver/documentation.md
+++ b/receiver/kymastatsreceiver/documentation.md
@@ -12,25 +12,9 @@ metrics:
     enabled: false
 ```
 
-### kyma.module.status.conditions
+### kyma.resource.status.conditions
 
-The module status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values.
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| reason | The reason of the module condition status. | Any Str |
-| status | The status of the module condition. | Any Str |
-| type | The type of the module condition. | Any Str |
-
-### kyma.module.status.state
-
-The module status state, metric value is 1 for last scraped module status state, including state as metric attribute.
+The resource status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -40,11 +24,30 @@ The module status state, metric value is 1 for last scraped module status state,
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
-| state | The state of the module status. | Any Str |
+| reason | The reason of the resource condition status. | Any Str |
+| status | The status of the resource condition. | Any Str |
+| type | The type of the resource condition. | Any Str |
+
+### kyma.resource.status.state
+
+The resource status state, metric value is 1 for last scraped resource status state, including state as metric attribute.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| 1 | Gauge | Int |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| state | The state of the resource status. | Any Str |
 
 ## Resource Attributes
 
 | Name | Description | Values | Enabled |
 | ---- | ----------- | ------ | ------- |
 | k8s.namespace.name | The name of the namespace that the resource is running in | Any Str | true |
-| kyma.module.name | The module kind | Any Str | true |
+| k8s.resource.group | The resource group | Any Str | true |
+| k8s.resource.kind | The resource kind | Any Str | true |
+| k8s.resource.name | The resource name | Any Str | true |
+| k8s.resource.version | The resource version | Any Str | true |

--- a/receiver/kymastatsreceiver/documentation.md
+++ b/receiver/kymastatsreceiver/documentation.md
@@ -30,7 +30,7 @@ The resource status conditions. Possible metric values for condition status are 
 
 ### kyma.resource.status.state
 
-The resource status state, metric value is 1 for last scraped resource status state, including state as metric attribute.
+The resource status state, metric value is 1 for the last scraped resource status state, including state as metric attribute.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |

--- a/receiver/kymastatsreceiver/internal/metadata/generated_config.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_config.go
@@ -28,16 +28,16 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for kymastats metrics.
 type MetricsConfig struct {
-	KymaModuleStatusConditions MetricConfig `mapstructure:"kyma.module.status.conditions"`
-	KymaModuleStatusState      MetricConfig `mapstructure:"kyma.module.status.state"`
+	KymaResourceStatusConditions MetricConfig `mapstructure:"kyma.resource.status.conditions"`
+	KymaResourceStatusState      MetricConfig `mapstructure:"kyma.resource.status.state"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
-		KymaModuleStatusConditions: MetricConfig{
+		KymaResourceStatusConditions: MetricConfig{
 			Enabled: true,
 		},
-		KymaModuleStatusState: MetricConfig{
+		KymaResourceStatusState: MetricConfig{
 			Enabled: true,
 		},
 	}
@@ -71,8 +71,11 @@ func (rac *ResourceAttributeConfig) Unmarshal(parser *confmap.Conf) error {
 
 // ResourceAttributesConfig provides config for kymastats resource attributes.
 type ResourceAttributesConfig struct {
-	K8sNamespaceName ResourceAttributeConfig `mapstructure:"k8s.namespace.name"`
-	KymaModuleName   ResourceAttributeConfig `mapstructure:"kyma.module.name"`
+	K8sNamespaceName   ResourceAttributeConfig `mapstructure:"k8s.namespace.name"`
+	K8sResourceGroup   ResourceAttributeConfig `mapstructure:"k8s.resource.group"`
+	K8sResourceKind    ResourceAttributeConfig `mapstructure:"k8s.resource.kind"`
+	K8sResourceName    ResourceAttributeConfig `mapstructure:"k8s.resource.name"`
+	K8sResourceVersion ResourceAttributeConfig `mapstructure:"k8s.resource.version"`
 }
 
 func DefaultResourceAttributesConfig() ResourceAttributesConfig {
@@ -80,7 +83,16 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 		K8sNamespaceName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		KymaModuleName: ResourceAttributeConfig{
+		K8sResourceGroup: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		K8sResourceKind: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		K8sResourceName: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		K8sResourceVersion: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/kymastatsreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_config_test.go
@@ -25,12 +25,15 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					KymaModuleStatusConditions: MetricConfig{Enabled: true},
-					KymaModuleStatusState:      MetricConfig{Enabled: true},
+					KymaResourceStatusConditions: MetricConfig{Enabled: true},
+					KymaResourceStatusState:      MetricConfig{Enabled: true},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
-					K8sNamespaceName: ResourceAttributeConfig{Enabled: true},
-					KymaModuleName:   ResourceAttributeConfig{Enabled: true},
+					K8sNamespaceName:   ResourceAttributeConfig{Enabled: true},
+					K8sResourceGroup:   ResourceAttributeConfig{Enabled: true},
+					K8sResourceKind:    ResourceAttributeConfig{Enabled: true},
+					K8sResourceName:    ResourceAttributeConfig{Enabled: true},
+					K8sResourceVersion: ResourceAttributeConfig{Enabled: true},
 				},
 			},
 		},
@@ -38,12 +41,15 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					KymaModuleStatusConditions: MetricConfig{Enabled: false},
-					KymaModuleStatusState:      MetricConfig{Enabled: false},
+					KymaResourceStatusConditions: MetricConfig{Enabled: false},
+					KymaResourceStatusState:      MetricConfig{Enabled: false},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
-					K8sNamespaceName: ResourceAttributeConfig{Enabled: false},
-					KymaModuleName:   ResourceAttributeConfig{Enabled: false},
+					K8sNamespaceName:   ResourceAttributeConfig{Enabled: false},
+					K8sResourceGroup:   ResourceAttributeConfig{Enabled: false},
+					K8sResourceKind:    ResourceAttributeConfig{Enabled: false},
+					K8sResourceName:    ResourceAttributeConfig{Enabled: false},
+					K8sResourceVersion: ResourceAttributeConfig{Enabled: false},
 				},
 			},
 		},
@@ -80,15 +86,21 @@ func TestResourceAttributesConfig(t *testing.T) {
 		{
 			name: "all_set",
 			want: ResourceAttributesConfig{
-				K8sNamespaceName: ResourceAttributeConfig{Enabled: true},
-				KymaModuleName:   ResourceAttributeConfig{Enabled: true},
+				K8sNamespaceName:   ResourceAttributeConfig{Enabled: true},
+				K8sResourceGroup:   ResourceAttributeConfig{Enabled: true},
+				K8sResourceKind:    ResourceAttributeConfig{Enabled: true},
+				K8sResourceName:    ResourceAttributeConfig{Enabled: true},
+				K8sResourceVersion: ResourceAttributeConfig{Enabled: true},
 			},
 		},
 		{
 			name: "none_set",
 			want: ResourceAttributesConfig{
-				K8sNamespaceName: ResourceAttributeConfig{Enabled: false},
-				KymaModuleName:   ResourceAttributeConfig{Enabled: false},
+				K8sNamespaceName:   ResourceAttributeConfig{Enabled: false},
+				K8sResourceGroup:   ResourceAttributeConfig{Enabled: false},
+				K8sResourceKind:    ResourceAttributeConfig{Enabled: false},
+				K8sResourceName:    ResourceAttributeConfig{Enabled: false},
+				K8sResourceVersion: ResourceAttributeConfig{Enabled: false},
 			},
 		},
 	}

--- a/receiver/kymastatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_metrics.go
@@ -74,7 +74,7 @@ type metricKymaResourceStatusState struct {
 // init fills kyma.resource.status.state metric with initial data.
 func (m *metricKymaResourceStatusState) init() {
 	m.data.SetName("kyma.resource.status.state")
-	m.data.SetDescription("The resource status state, metric value is 1 for last scraped resource status state, including state as metric attribute.")
+	m.data.SetDescription("The resource status state, metric value is 1 for the last scraped resource status state, including state as metric attribute.")
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)

--- a/receiver/kymastatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_metrics.go
@@ -12,22 +12,22 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-type metricKymaModuleStatusConditions struct {
+type metricKymaResourceStatusConditions struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills kyma.module.status.conditions metric with initial data.
-func (m *metricKymaModuleStatusConditions) init() {
-	m.data.SetName("kyma.module.status.conditions")
-	m.data.SetDescription("The module status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values.")
+// init fills kyma.resource.status.conditions metric with initial data.
+func (m *metricKymaResourceStatusConditions) init() {
+	m.data.SetName("kyma.resource.status.conditions")
+	m.data.SetDescription("The resource status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values.")
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricKymaModuleStatusConditions) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, reasonAttributeValue string, statusAttributeValue string, typeAttributeValue string) {
+func (m *metricKymaResourceStatusConditions) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, reasonAttributeValue string, statusAttributeValue string, typeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -41,14 +41,14 @@ func (m *metricKymaModuleStatusConditions) recordDataPoint(start pcommon.Timesta
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricKymaModuleStatusConditions) updateCapacity() {
+func (m *metricKymaResourceStatusConditions) updateCapacity() {
 	if m.data.Gauge().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Gauge().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricKymaModuleStatusConditions) emit(metrics pmetric.MetricSlice) {
+func (m *metricKymaResourceStatusConditions) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -56,8 +56,8 @@ func (m *metricKymaModuleStatusConditions) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricKymaModuleStatusConditions(cfg MetricConfig) metricKymaModuleStatusConditions {
-	m := metricKymaModuleStatusConditions{config: cfg}
+func newMetricKymaResourceStatusConditions(cfg MetricConfig) metricKymaResourceStatusConditions {
+	m := metricKymaResourceStatusConditions{config: cfg}
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -65,22 +65,22 @@ func newMetricKymaModuleStatusConditions(cfg MetricConfig) metricKymaModuleStatu
 	return m
 }
 
-type metricKymaModuleStatusState struct {
+type metricKymaResourceStatusState struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills kyma.module.status.state metric with initial data.
-func (m *metricKymaModuleStatusState) init() {
-	m.data.SetName("kyma.module.status.state")
-	m.data.SetDescription("The module status state, metric value is 1 for last scraped module status state, including state as metric attribute.")
+// init fills kyma.resource.status.state metric with initial data.
+func (m *metricKymaResourceStatusState) init() {
+	m.data.SetName("kyma.resource.status.state")
+	m.data.SetDescription("The resource status state, metric value is 1 for last scraped resource status state, including state as metric attribute.")
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricKymaModuleStatusState) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stateAttributeValue string) {
+func (m *metricKymaResourceStatusState) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -92,14 +92,14 @@ func (m *metricKymaModuleStatusState) recordDataPoint(start pcommon.Timestamp, t
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricKymaModuleStatusState) updateCapacity() {
+func (m *metricKymaResourceStatusState) updateCapacity() {
 	if m.data.Gauge().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Gauge().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricKymaModuleStatusState) emit(metrics pmetric.MetricSlice) {
+func (m *metricKymaResourceStatusState) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -107,8 +107,8 @@ func (m *metricKymaModuleStatusState) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricKymaModuleStatusState(cfg MetricConfig) metricKymaModuleStatusState {
-	m := metricKymaModuleStatusState{config: cfg}
+func newMetricKymaResourceStatusState(cfg MetricConfig) metricKymaResourceStatusState {
+	m := metricKymaResourceStatusState{config: cfg}
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -119,15 +119,15 @@ func newMetricKymaModuleStatusState(cfg MetricConfig) metricKymaModuleStatusStat
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
-	config                           MetricsBuilderConfig // config of the metrics builder.
-	startTime                        pcommon.Timestamp    // start time that will be applied to all recorded data points.
-	metricsCapacity                  int                  // maximum observed number of metrics per resource.
-	metricsBuffer                    pmetric.Metrics      // accumulates metrics data before emitting.
-	buildInfo                        component.BuildInfo  // contains version information.
-	resourceAttributeIncludeFilter   map[string]filter.Filter
-	resourceAttributeExcludeFilter   map[string]filter.Filter
-	metricKymaModuleStatusConditions metricKymaModuleStatusConditions
-	metricKymaModuleStatusState      metricKymaModuleStatusState
+	config                             MetricsBuilderConfig // config of the metrics builder.
+	startTime                          pcommon.Timestamp    // start time that will be applied to all recorded data points.
+	metricsCapacity                    int                  // maximum observed number of metrics per resource.
+	metricsBuffer                      pmetric.Metrics      // accumulates metrics data before emitting.
+	buildInfo                          component.BuildInfo  // contains version information.
+	resourceAttributeIncludeFilter     map[string]filter.Filter
+	resourceAttributeExcludeFilter     map[string]filter.Filter
+	metricKymaResourceStatusConditions metricKymaResourceStatusConditions
+	metricKymaResourceStatusState      metricKymaResourceStatusState
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -142,14 +142,14 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:                           mbc,
-		startTime:                        pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:                    pmetric.NewMetrics(),
-		buildInfo:                        settings.BuildInfo,
-		metricKymaModuleStatusConditions: newMetricKymaModuleStatusConditions(mbc.Metrics.KymaModuleStatusConditions),
-		metricKymaModuleStatusState:      newMetricKymaModuleStatusState(mbc.Metrics.KymaModuleStatusState),
-		resourceAttributeIncludeFilter:   make(map[string]filter.Filter),
-		resourceAttributeExcludeFilter:   make(map[string]filter.Filter),
+		config:                             mbc,
+		startTime:                          pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                      pmetric.NewMetrics(),
+		buildInfo:                          settings.BuildInfo,
+		metricKymaResourceStatusConditions: newMetricKymaResourceStatusConditions(mbc.Metrics.KymaResourceStatusConditions),
+		metricKymaResourceStatusState:      newMetricKymaResourceStatusState(mbc.Metrics.KymaResourceStatusState),
+		resourceAttributeIncludeFilter:     make(map[string]filter.Filter),
+		resourceAttributeExcludeFilter:     make(map[string]filter.Filter),
 	}
 	if mbc.ResourceAttributes.K8sNamespaceName.MetricsInclude != nil {
 		mb.resourceAttributeIncludeFilter["k8s.namespace.name"] = filter.CreateFilter(mbc.ResourceAttributes.K8sNamespaceName.MetricsInclude)
@@ -157,11 +157,29 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 	if mbc.ResourceAttributes.K8sNamespaceName.MetricsExclude != nil {
 		mb.resourceAttributeExcludeFilter["k8s.namespace.name"] = filter.CreateFilter(mbc.ResourceAttributes.K8sNamespaceName.MetricsExclude)
 	}
-	if mbc.ResourceAttributes.KymaModuleName.MetricsInclude != nil {
-		mb.resourceAttributeIncludeFilter["kyma.module.name"] = filter.CreateFilter(mbc.ResourceAttributes.KymaModuleName.MetricsInclude)
+	if mbc.ResourceAttributes.K8sResourceGroup.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["k8s.resource.group"] = filter.CreateFilter(mbc.ResourceAttributes.K8sResourceGroup.MetricsInclude)
 	}
-	if mbc.ResourceAttributes.KymaModuleName.MetricsExclude != nil {
-		mb.resourceAttributeExcludeFilter["kyma.module.name"] = filter.CreateFilter(mbc.ResourceAttributes.KymaModuleName.MetricsExclude)
+	if mbc.ResourceAttributes.K8sResourceGroup.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["k8s.resource.group"] = filter.CreateFilter(mbc.ResourceAttributes.K8sResourceGroup.MetricsExclude)
+	}
+	if mbc.ResourceAttributes.K8sResourceKind.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["k8s.resource.kind"] = filter.CreateFilter(mbc.ResourceAttributes.K8sResourceKind.MetricsInclude)
+	}
+	if mbc.ResourceAttributes.K8sResourceKind.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["k8s.resource.kind"] = filter.CreateFilter(mbc.ResourceAttributes.K8sResourceKind.MetricsExclude)
+	}
+	if mbc.ResourceAttributes.K8sResourceName.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["k8s.resource.name"] = filter.CreateFilter(mbc.ResourceAttributes.K8sResourceName.MetricsInclude)
+	}
+	if mbc.ResourceAttributes.K8sResourceName.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["k8s.resource.name"] = filter.CreateFilter(mbc.ResourceAttributes.K8sResourceName.MetricsExclude)
+	}
+	if mbc.ResourceAttributes.K8sResourceVersion.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["k8s.resource.version"] = filter.CreateFilter(mbc.ResourceAttributes.K8sResourceVersion.MetricsInclude)
+	}
+	if mbc.ResourceAttributes.K8sResourceVersion.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["k8s.resource.version"] = filter.CreateFilter(mbc.ResourceAttributes.K8sResourceVersion.MetricsExclude)
 	}
 
 	for _, op := range options {
@@ -224,8 +242,8 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	ils.Scope().SetName("github.com/kyma-project/opentelemetry-collector-components/receiver/kymastatsreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
-	mb.metricKymaModuleStatusConditions.emit(ils.Metrics())
-	mb.metricKymaModuleStatusState.emit(ils.Metrics())
+	mb.metricKymaResourceStatusConditions.emit(ils.Metrics())
+	mb.metricKymaResourceStatusState.emit(ils.Metrics())
 
 	for _, op := range rmo {
 		op(rm)
@@ -257,14 +275,14 @@ func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	return metrics
 }
 
-// RecordKymaModuleStatusConditionsDataPoint adds a data point to kyma.module.status.conditions metric.
-func (mb *MetricsBuilder) RecordKymaModuleStatusConditionsDataPoint(ts pcommon.Timestamp, val int64, reasonAttributeValue string, statusAttributeValue string, typeAttributeValue string) {
-	mb.metricKymaModuleStatusConditions.recordDataPoint(mb.startTime, ts, val, reasonAttributeValue, statusAttributeValue, typeAttributeValue)
+// RecordKymaResourceStatusConditionsDataPoint adds a data point to kyma.resource.status.conditions metric.
+func (mb *MetricsBuilder) RecordKymaResourceStatusConditionsDataPoint(ts pcommon.Timestamp, val int64, reasonAttributeValue string, statusAttributeValue string, typeAttributeValue string) {
+	mb.metricKymaResourceStatusConditions.recordDataPoint(mb.startTime, ts, val, reasonAttributeValue, statusAttributeValue, typeAttributeValue)
 }
 
-// RecordKymaModuleStatusStateDataPoint adds a data point to kyma.module.status.state metric.
-func (mb *MetricsBuilder) RecordKymaModuleStatusStateDataPoint(ts pcommon.Timestamp, val int64, stateAttributeValue string) {
-	mb.metricKymaModuleStatusState.recordDataPoint(mb.startTime, ts, val, stateAttributeValue)
+// RecordKymaResourceStatusStateDataPoint adds a data point to kyma.resource.status.state metric.
+func (mb *MetricsBuilder) RecordKymaResourceStatusStateDataPoint(ts pcommon.Timestamp, val int64, stateAttributeValue string) {
+	mb.metricKymaResourceStatusState.recordDataPoint(mb.startTime, ts, val, stateAttributeValue)
 }
 
 // Reset resets metrics builder to its initial state. It should be used when external metrics source is restarted,

--- a/receiver/kymastatsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_metrics_test.go
@@ -130,7 +130,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["kyma.resource.status.state"] = true
 					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The resource status state, metric value is 1 for last scraped resource status state, including state as metric attribute.", ms.At(i).Description())
+					assert.Equal(t, "The resource status state, metric value is 1 for the last scraped resource status state, including state as metric attribute.", ms.At(i).Description())
 					assert.Equal(t, "1", ms.At(i).Unit())
 					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())

--- a/receiver/kymastatsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_metrics_test.go
@@ -70,15 +70,18 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordKymaModuleStatusConditionsDataPoint(ts, 1, "reason-val", "status-val", "type-val")
+			mb.RecordKymaResourceStatusConditionsDataPoint(ts, 1, "reason-val", "status-val", "type-val")
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordKymaModuleStatusStateDataPoint(ts, 1, "state-val")
+			mb.RecordKymaResourceStatusStateDataPoint(ts, 1, "state-val")
 
 			rb := mb.NewResourceBuilder()
 			rb.SetK8sNamespaceName("k8s.namespace.name-val")
-			rb.SetKymaModuleName("kyma.module.name-val")
+			rb.SetK8sResourceGroup("k8s.resource.group-val")
+			rb.SetK8sResourceKind("k8s.resource.kind-val")
+			rb.SetK8sResourceName("k8s.resource.name-val")
+			rb.SetK8sResourceVersion("k8s.resource.version-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
 
@@ -101,12 +104,12 @@ func TestMetricsBuilder(t *testing.T) {
 			validatedMetrics := make(map[string]bool)
 			for i := 0; i < ms.Len(); i++ {
 				switch ms.At(i).Name() {
-				case "kyma.module.status.conditions":
-					assert.False(t, validatedMetrics["kyma.module.status.conditions"], "Found a duplicate in the metrics slice: kyma.module.status.conditions")
-					validatedMetrics["kyma.module.status.conditions"] = true
+				case "kyma.resource.status.conditions":
+					assert.False(t, validatedMetrics["kyma.resource.status.conditions"], "Found a duplicate in the metrics slice: kyma.resource.status.conditions")
+					validatedMetrics["kyma.resource.status.conditions"] = true
 					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The module status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values.", ms.At(i).Description())
+					assert.Equal(t, "The resource status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values.", ms.At(i).Description())
 					assert.Equal(t, "1", ms.At(i).Unit())
 					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
@@ -122,12 +125,12 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("type")
 					assert.True(t, ok)
 					assert.EqualValues(t, "type-val", attrVal.Str())
-				case "kyma.module.status.state":
-					assert.False(t, validatedMetrics["kyma.module.status.state"], "Found a duplicate in the metrics slice: kyma.module.status.state")
-					validatedMetrics["kyma.module.status.state"] = true
+				case "kyma.resource.status.state":
+					assert.False(t, validatedMetrics["kyma.resource.status.state"], "Found a duplicate in the metrics slice: kyma.resource.status.state")
+					validatedMetrics["kyma.resource.status.state"] = true
 					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The module status state, metric value is 1 for last scraped module status state, including state as metric attribute.", ms.At(i).Description())
+					assert.Equal(t, "The resource status state, metric value is 1 for last scraped resource status state, including state as metric attribute.", ms.At(i).Description())
 					assert.Equal(t, "1", ms.At(i).Unit())
 					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())

--- a/receiver/kymastatsreceiver/internal/metadata/generated_resource.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_resource.go
@@ -28,10 +28,31 @@ func (rb *ResourceBuilder) SetK8sNamespaceName(val string) {
 	}
 }
 
-// SetKymaModuleName sets provided value as "kyma.module.name" attribute.
-func (rb *ResourceBuilder) SetKymaModuleName(val string) {
-	if rb.config.KymaModuleName.Enabled {
-		rb.res.Attributes().PutStr("kyma.module.name", val)
+// SetK8sResourceGroup sets provided value as "k8s.resource.group" attribute.
+func (rb *ResourceBuilder) SetK8sResourceGroup(val string) {
+	if rb.config.K8sResourceGroup.Enabled {
+		rb.res.Attributes().PutStr("k8s.resource.group", val)
+	}
+}
+
+// SetK8sResourceKind sets provided value as "k8s.resource.kind" attribute.
+func (rb *ResourceBuilder) SetK8sResourceKind(val string) {
+	if rb.config.K8sResourceKind.Enabled {
+		rb.res.Attributes().PutStr("k8s.resource.kind", val)
+	}
+}
+
+// SetK8sResourceName sets provided value as "k8s.resource.name" attribute.
+func (rb *ResourceBuilder) SetK8sResourceName(val string) {
+	if rb.config.K8sResourceName.Enabled {
+		rb.res.Attributes().PutStr("k8s.resource.name", val)
+	}
+}
+
+// SetK8sResourceVersion sets provided value as "k8s.resource.version" attribute.
+func (rb *ResourceBuilder) SetK8sResourceVersion(val string) {
+	if rb.config.K8sResourceVersion.Enabled {
+		rb.res.Attributes().PutStr("k8s.resource.version", val)
 	}
 }
 

--- a/receiver/kymastatsreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_resource_test.go
@@ -14,16 +14,19 @@ func TestResourceBuilder(t *testing.T) {
 			cfg := loadResourceAttributesConfig(t, test)
 			rb := NewResourceBuilder(cfg)
 			rb.SetK8sNamespaceName("k8s.namespace.name-val")
-			rb.SetKymaModuleName("kyma.module.name-val")
+			rb.SetK8sResourceGroup("k8s.resource.group-val")
+			rb.SetK8sResourceKind("k8s.resource.kind-val")
+			rb.SetK8sResourceName("k8s.resource.name-val")
+			rb.SetK8sResourceVersion("k8s.resource.version-val")
 
 			res := rb.Emit()
 			assert.Equal(t, 0, rb.Emit().Attributes().Len()) // Second call should return empty Resource
 
 			switch test {
 			case "default":
-				assert.Equal(t, 2, res.Attributes().Len())
+				assert.Equal(t, 5, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 2, res.Attributes().Len())
+				assert.Equal(t, 5, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
@@ -36,10 +39,25 @@ func TestResourceBuilder(t *testing.T) {
 			if ok {
 				assert.EqualValues(t, "k8s.namespace.name-val", val.Str())
 			}
-			val, ok = res.Attributes().Get("kyma.module.name")
+			val, ok = res.Attributes().Get("k8s.resource.group")
 			assert.True(t, ok)
 			if ok {
-				assert.EqualValues(t, "kyma.module.name-val", val.Str())
+				assert.EqualValues(t, "k8s.resource.group-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("k8s.resource.kind")
+			assert.True(t, ok)
+			if ok {
+				assert.EqualValues(t, "k8s.resource.kind-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("k8s.resource.name")
+			assert.True(t, ok)
+			if ok {
+				assert.EqualValues(t, "k8s.resource.name-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("k8s.resource.version")
+			assert.True(t, ok)
+			if ok {
+				assert.EqualValues(t, "k8s.resource.version-val", val.Str())
 			}
 		})
 	}

--- a/receiver/kymastatsreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/kymastatsreceiver/internal/metadata/testdata/config.yaml
@@ -1,25 +1,37 @@
 default:
 all_set:
   metrics:
-    kyma.module.status.conditions:
+    kyma.resource.status.conditions:
       enabled: true
-    kyma.module.status.state:
+    kyma.resource.status.state:
       enabled: true
   resource_attributes:
     k8s.namespace.name:
       enabled: true
-    kyma.module.name:
+    k8s.resource.group:
+      enabled: true
+    k8s.resource.kind:
+      enabled: true
+    k8s.resource.name:
+      enabled: true
+    k8s.resource.version:
       enabled: true
 none_set:
   metrics:
-    kyma.module.status.conditions:
+    kyma.resource.status.conditions:
       enabled: false
-    kyma.module.status.state:
+    kyma.resource.status.state:
       enabled: false
   resource_attributes:
     k8s.namespace.name:
       enabled: false
-    kyma.module.name:
+    k8s.resource.group:
+      enabled: false
+    k8s.resource.kind:
+      enabled: false
+    k8s.resource.name:
+      enabled: false
+    k8s.resource.version:
       enabled: false
 filter_set_include:
   resource_attributes:
@@ -27,7 +39,19 @@ filter_set_include:
       enabled: true
       metrics_include:
         - regexp: ".*"
-    kyma.module.name:
+    k8s.resource.group:
+      enabled: true
+      metrics_include:
+        - regexp: ".*"
+    k8s.resource.kind:
+      enabled: true
+      metrics_include:
+        - regexp: ".*"
+    k8s.resource.name:
+      enabled: true
+      metrics_include:
+        - regexp: ".*"
+    k8s.resource.version:
       enabled: true
       metrics_include:
         - regexp: ".*"
@@ -37,7 +61,19 @@ filter_set_exclude:
       enabled: true
       metrics_exclude:
         - strict: "k8s.namespace.name-val"
-    kyma.module.name:
+    k8s.resource.group:
       enabled: true
       metrics_exclude:
-        - strict: "kyma.module.name-val"
+        - strict: "k8s.resource.group-val"
+    k8s.resource.kind:
+      enabled: true
+      metrics_exclude:
+        - strict: "k8s.resource.kind-val"
+    k8s.resource.name:
+      enabled: true
+      metrics_exclude:
+        - strict: "k8s.resource.name-val"
+    k8s.resource.version:
+      enabled: true
+      metrics_exclude:
+        - strict: "k8s.resource.version-val"

--- a/receiver/kymastatsreceiver/metadata.yaml
+++ b/receiver/kymastatsreceiver/metadata.yaml
@@ -18,35 +18,47 @@ resource_attributes:
     description: "The name of the namespace that the resource is running in"
     enabled: true
     type: string
-  kyma.module.name:
-    description: "The module kind"
+  k8s.resource.name:
+    description: "The resource name"
+    enabled: true
+    type: string
+  k8s.resource.kind:
+    description: "The resource kind"
+    enabled: true
+    type: string
+  k8s.resource.group:
+    description: "The resource group"
+    enabled: true
+    type: string
+  k8s.resource.version:
+    description: "The resource version"
     enabled: true
     type: string
 attributes:
   state:
-    description: The state of the module status.
+    description: The state of the resource status.
     type: string
   reason:
-    description: The reason of the module condition status.
+    description: The reason of the resource condition status.
     type: string
   status:
-    description: The status of the module condition.
+    description: The status of the resource condition.
     type: string
   type:
-    description: The type of the module condition.
+    description: The type of the resource condition.
     type: string
 metrics:
-  kyma.module.status.state:
+  kyma.resource.status.state:
     enabled: true
-    description: "The module status state, metric value is 1 for last scraped module status state, including state as metric attribute."
+    description: "The resource status state, metric value is 1 for last scraped resource status state, including state as metric attribute."
     unit: "1"
     gauge:
       value_type: int
     attributes: ["state"]
 
-  kyma.module.status.conditions:
+  kyma.resource.status.conditions:
     enabled: true
-    description: "The module status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values."
+    description: "The resource status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values."
     unit: "1"
     gauge:
       value_type: int

--- a/receiver/kymastatsreceiver/metadata.yaml
+++ b/receiver/kymastatsreceiver/metadata.yaml
@@ -50,7 +50,7 @@ attributes:
 metrics:
   kyma.resource.status.state:
     enabled: true
-    description: "The resource status state, metric value is 1 for last scraped resource status state, including state as metric attribute."
+    description: "The resource status state, metric value is 1 for the last scraped resource status state, including state as metric attribute."
     unit: "1"
     gauge:
       value_type: int

--- a/receiver/kymastatsreceiver/testdata/config.yaml
+++ b/receiver/kymastatsreceiver/testdata/config.yaml
@@ -1,12 +1,12 @@
 kymastats:
-  modules:
+  resources:
     - group: operator.kyma-project.io
       version: v1alpha1
       resource: telemetries
 kymastats/sa:
   auth_type: "serviceAccount"
   collection_interval: 10s
-  modules:
+  resources:
     - group: operator.kyma-project.io
       version: v1alpha1
       resource: telemetries
@@ -14,30 +14,30 @@ kymastats/kubeconfig:
   auth_type: "kubeConfig"
   context: "k8s-context"
   collection_interval: 30s
-  modules:
+  resources:
     - group: operator.kyma-project.io
       version: v1alpha1
       resource: telemetries
 kymastats/invalidauth:
   auth_type: "123"
   collection_interval: 30s
-  modules:
+  resources:
     - group: operator.kyma-project.io
       version: v1alpha1
       resource: telemetries
 kymastats/invalidinterval:
   auth_type: "kubeConfig"
   collection_interval: 0s
-  modules:
+  resources:
     - group: operator.kyma-project.io
       version: v1alpha1
       resource: telemetries
 kymastats/none:
   auth_type: "none"
   collection_interval: 60s
-  modules:
+  resources:
     - group: operator.kyma-project.io
       version: v1alpha1
       resource: telemetries
-kymastats/nomodules:
+kymastats/noresources:
   auth_type: "kubeConfig"

--- a/receiver/kymastatsreceiver/testdata/metrics.yaml
+++ b/receiver/kymastatsreceiver/testdata/metrics.yaml
@@ -4,12 +4,22 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: kyma-system
-        - key: kyma.module.name
+        - key: k8s.resource.name
           value:
-            stringValue: Telemetry
+            stringValue: default
+        - key: k8s.resource.group
+          value:
+            stringValue: operator.kyma-project.io
+        - key: k8s.resource.version
+          value:
+            stringValue: v1
+        - key: k8s.resource.kind
+          value:
+            stringValue: telemetries
+
     scopeMetrics:
       - metrics:
-          - description: The module status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values.
+          - description: The resource status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values.
             gauge:
               dataPoints:
                 - asInt: "1"
@@ -23,9 +33,9 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: TelemetryHealthy
-            name: kyma.module.status.conditions
+            name: kyma.resource.status.conditions
             unit: "1"
-          - description: The module status state, metric value is 1 for last scraped module status state, including state as metric attribute.
+          - description: The resource status state, metric value is 1 for last scraped resource status state, including state as metric attribute.
             gauge:
               dataPoints:
                 - asInt: "1"
@@ -33,46 +43,78 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: Ready
-            name: kyma.module.status.state
+            name: kyma.resource.status.state
             unit: "1"
         scope:
           name: github.com/kyma-project/opentelemetry-collector-components/receiver/kymastatsreceiver
           version: latest
   - resource:
       attributes:
-        - key: k8s.namespace.name
+        - key: k8s.resource.name
           value:
-            stringValue: kyma-system
-        - key: kyma.module.name
+            stringValue: pipe-1
+        - key: k8s.resource.group
           value:
-            stringValue: Istio
+            stringValue: telemetry.kyma-project.io
+        - key: k8s.resource.version
+          value:
+            stringValue: v1alpha1
+        - key: k8s.resource.kind
+          value:
+            stringValue: logpipelines
+
     scopeMetrics:
       - metrics:
-          - description: The module status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values.
+          - description: The resource status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values.
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: reason
+                      value:
+                        stringValue: AgentReady
+                    - key: status
+                      value:
+                        stringValue: "True"
+                    - key: type
+                      value:
+                        stringValue: AgentHealthy
+            name: kyma.resource.status.conditions
+            unit: "1"
+        scope:
+          name: github.com/kyma-project/opentelemetry-collector-components/receiver/kymastatsreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: k8s.resource.group
+          value:
+            stringValue: telemetry.kyma-project.io
+        - key: k8s.resource.version
+          value:
+            stringValue: v1alpha1
+        - key: k8s.resource.kind
+          value:
+            stringValue: logpipelines
+        - key: k8s.resource.name
+          value:
+            stringValue: pipe-2
+    scopeMetrics:
+      - metrics:
+          - description: The resource status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values.
             gauge:
               dataPoints:
                 - asInt: "0"
                   attributes:
                     - key: reason
                       value:
-                        stringValue: IstiodDown
+                        stringValue: AgentNotReady
                     - key: status
                       value:
                         stringValue: "False"
                     - key: type
                       value:
-                        stringValue: IstioHealthy
-            name: kyma.module.status.conditions
-            unit: "1"
-          - description: The module status state, metric value is 1 for last scraped module status state, including state as metric attribute.
-            gauge:
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: Warning
-            name: kyma.module.status.state
+                        stringValue: AgentHealthy
+            name: kyma.resource.status.conditions
             unit: "1"
         scope:
           name: github.com/kyma-project/opentelemetry-collector-components/receiver/kymastatsreceiver

--- a/receiver/kymastatsreceiver/testdata/metrics.yaml
+++ b/receiver/kymastatsreceiver/testdata/metrics.yaml
@@ -35,7 +35,7 @@ resourceMetrics:
                         stringValue: TelemetryHealthy
             name: kyma.resource.status.conditions
             unit: "1"
-          - description: The resource status state, metric value is 1 for last scraped resource status state, including state as metric attribute.
+          - description: The resource status state, metric value is 1 for the last scraped resource status state, including state as metric attribute.
             gauge:
               dataPoints:
                 - asInt: "1"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Rename modules to resources
- Look for all resources, dont stop at first one


Changes refer to particular issues, PRs or documents:

-  https://github.com/kyma-project/telemetry-manager/issues/1388

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [x] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
