### PR TITLE
docs: Improve release process documentation

### DIFF
--- a/docs/contributor/releasing.md
+++ b/docs/contributor/releasing.md
@@ -18,19 +18,14 @@ This release process covers the steps to release new major and minor versions fo
    git push upstream {RELEASE_BRANCH}
    ```
 
-6. To make sure that the release tags point to the HEAD commit of the `opentelemetry-collector-components/{RELEASE_BRANCH}` branch, rebase the upstream branch into the local branch after the merge was successful.
-
-   ```bash
-   git rebase upstream/{RELEASE_BRANCH} {RELEASE_BRANCH}
-   ```
-
-7. In the `opentelemetry-collector-components/{RELEASE_BRANCH}` branch, create release tags for the HEAD commit.
+5. In the `opentelemetry-collector-components/{RELEASE_BRANCH}` branch, create release tags for the HEAD commit.
 
    ```bash
    git tag {RELEASE_VERSION}
    ```
+   Replace {RELEASE_VERSION} with the new release version, for example, `1.0.0`
 
-8. Push the tag to the upstream repository.
+6. Push the tag to the upstream repository.
 
    ```bash
    git push {REPOSITORY_REMOTE} {RELEASE_VERSION}
@@ -38,7 +33,7 @@ This release process covers the steps to release new major and minor versions fo
 
    The {RELEASE_VERSION} tag triggers a GitHub action (`GitHub Release`).
 
-9. Verify the [status](https://github.com/kyma-project/opentelemetry-collector-components/actions) of the GitHub action (`GitHub Release`).
+7. Verify the [status](https://github.com/kyma-project/opentelemetry-collector-components/actions) of the GitHub action (`GitHub Release`).
    - After the GitHub action succeeded, the new GitHub release is available under [releases](https://github.com/kyma-project/opentelemetry-collector-components/releases).
    - If the GitHub action fails, re-trigger it by removing the {RELEASE_VERSION} tag from upstream and pushing it again:
 
@@ -47,7 +42,7 @@ This release process covers the steps to release new major and minor versions fo
      git push upstream v{RELEASE_VERSION}
      ```
 
-10. If the previous release was a bugfix version (patch release) that contains cherry-picked changes, these changes might appear again in the generated change log. If there are redundant entries, edit the release description and remove them.
+8. If the previous release was a bugfix version (patch release) that contains cherry-picked changes, these changes might appear again in the generated change log. If there are redundant entries, edit the release description and remove them.
 
 ## Changelog
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Remove unnecessary step of `rebase the upstream branch into the local branch after the merge was successful.`. There are no PRs merged to the release branch with the current process
- Clarify the format of the RELEASE_VERSION tag with an example similar to what we have in the telemetry-manager [release process](https://github.com/kyma-project/telemetry-manager/blob/main/docs/contributor/releasing.md?plain=1#L52)

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
