### PR TITLE
chore: Add testify to dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,9 @@ updates:
       k8s:
         patterns:
           - "k8s.io/*"
+      testify:
+        patterns:
+          - "github.com/stretchr/testify"
     labels:
       - "area/dependency"
       - "kind/chore"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Create a single testify bump for all go modules

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
