### PR TITLE
fix: Use version tag for tj-actions/changed-files

### DIFF
--- a/.github/workflows/pr-code-checks.yml
+++ b/.github/workflows/pr-code-checks.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get changed files
-        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
+        uses: tj-actions/changed-files@v46.0.1
         id: changed-files
         with:
           files_ignore: |


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Use a version tag for the tj-actions/changed-files GHA, to avoid future compromise problems

Changes refer to particular issues, PRs or documents:

- See: https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised and https://github.com/tj-actions/changed-files/releases/tag/v46.0.1

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
