### PR TITLE
chore: ensure PR title subject doesn't start with an uppercase character

### DIFF
--- a/.github/workflows/pr-github-checks.yml
+++ b/.github/workflows/pr-github-checks.yml
@@ -111,4 +111,10 @@ jobs:
             feat
             fix
             test
+          # ensures the subject doesn't start with an uppercase character
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
           requireScope: false


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- ensure PR title subject doesn't start with an uppercase character

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
