### PR TITLE
fix: export variable to set the config

### DIFF
--- a/processor/serviceenrichmentprocessor/factory.go
+++ b/processor/serviceenrichmentprocessor/factory.go
@@ -26,7 +26,7 @@ func NewFactory() processor.Factory {
 }
 
 type Config struct {
-	resourceAttributes []string `mapstructure:"resource_attributes"`
+	ResourceAttributes []string `mapstructure:"resource_attributes"`
 }
 
 func createDefaultConfig() component.Config { return Config{} }

--- a/processor/serviceenrichmentprocessor/service_enrichment_processor_metrics_test.go
+++ b/processor/serviceenrichmentprocessor/service_enrichment_processor_metrics_test.go
@@ -96,7 +96,7 @@ func TestProcessMetrics(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			config := Config{
-				resourceAttributes: []string{
+				ResourceAttributes: []string{
 					"kyma.kubernetes_io_app_name",
 					"kyma.app_name",
 				},

--- a/processor/serviceenrichmentprocessor/service_name_enrichment_processor.go
+++ b/processor/serviceenrichmentprocessor/service_name_enrichment_processor.go
@@ -32,8 +32,8 @@ type serviceEnrichmentProcessor struct {
 }
 
 func newServiceEnrichmentProcessor(logger *zap.Logger, cfg Config) *serviceEnrichmentProcessor {
-	attrKeys := cfg.resourceAttributes
-	attrKeys = append(attrKeys, cfg.resourceAttributes...)
+	attrKeys := cfg.ResourceAttributes
+	attrKeys = append(attrKeys, cfg.ResourceAttributes...)
 	attrKeys = append(attrKeys, defaultAttributeKeysPriority...)
 
 	return &serviceEnrichmentProcessor{

--- a/processor/serviceenrichmentprocessor/service_name_enrichment_processor_logs_test.go
+++ b/processor/serviceenrichmentprocessor/service_name_enrichment_processor_logs_test.go
@@ -89,7 +89,7 @@ func TestProcessLogs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sink := new(consumertest.LogsSink)
 			config := Config{
-				resourceAttributes: []string{
+				ResourceAttributes: []string{
 					"kyma.kubernetes_io_app_name",
 					"kyma.app_name",
 				},

--- a/processor/serviceenrichmentprocessor/service_name_enrichment_processor_test.go
+++ b/processor/serviceenrichmentprocessor/service_name_enrichment_processor_test.go
@@ -90,7 +90,7 @@ func TestFetchFirstAvailableServiceName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			logger := zap.NewNop()
 			config := Config{
-				resourceAttributes: []string{
+				ResourceAttributes: []string{
 					"kyma.kubernetes_io_app_name",
 					"kyma.app_name",
 				},
@@ -152,7 +152,7 @@ func TestSetServiceName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			logger := zap.NewNop()
 			config := Config{
-				resourceAttributes: []string{
+				ResourceAttributes: []string{
 					"kyma.kubernetes_io_app_name",
 					"kyma.app_name",
 				},

--- a/processor/serviceenrichmentprocessor/service_name_enrichment_processor_traces_test.go
+++ b/processor/serviceenrichmentprocessor/service_name_enrichment_processor_traces_test.go
@@ -98,7 +98,7 @@ func TestProcessTraces(t *testing.T) {
 			sink := new(consumertest.TracesSink)
 
 			config := Config{
-				resourceAttributes: []string{
+				ResourceAttributes: []string{
 					"kyma.kubernetes_io_app_name",
 					"kyma.app_name",
 				},


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- export the variable so that we can set the config 

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
