### PR TITLE
feat: add resource attributes for metrics scraped by the kymastatsreceiver as regular metric attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ go.work*
 # generated files of local builder setup
 cmd/otelkymacol/*.go
 cmd/otelkymacol/go.*
+/.claude/

--- a/docs/contributor/releasing.md
+++ b/docs/contributor/releasing.md
@@ -52,4 +52,4 @@ The subject must describe the change and follow the recommendations:
 - Describe a change using the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood).
  It must start with a present-tense verb, for example (but not limited to) Add, Document, Fix, Deprecate.
 - Start with an uppercase, and not finish with a full stop.
-- Apply Kyma [capitalization](https://github.com/kyma-project/community/blob/main/docs/guidelines/content-guidelines/02-style-and-terminology.md#capitalization) and [terminology](https://github.com/kyma-project/community/blob/main/docs/guidelines/content-guidelines/02-style-and-terminology.md#terminology) guides.
+- Apply Kyma [capitalization](https://github.com/kyma-project/community/blob/main/docs/guidelines/content-guidelines/04-style-and-terminology.md#capitalization) and [terminology](https://github.com/kyma-project/community/blob/main/docs/guidelines/content-guidelines/04-style-and-terminology.md#terminology) guides.

--- a/receiver/kymastatsreceiver/documentation.md
+++ b/receiver/kymastatsreceiver/documentation.md
@@ -24,9 +24,14 @@ The resource status conditions. Possible metric values for condition status are 
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| reason | The reason of the resource condition status. | Any Str | Recommended |
-| status | The status of the resource condition. | Any Str | Recommended |
-| type | The type of the resource condition. | Any Str | Recommended |
+| group | The API group of the Kubernetes resource | Any Str | Recommended |
+| kind | The kind of the Kubernetes resource | Any Str | Recommended |
+| name | The name of the Kubernetes resource instance | Any Str | Recommended |
+| namespace | The Kubernetes namespace where the resource is located | Any Str | Recommended |
+| reason | The reason for the resource condition status. | Any Str | Recommended |
+| status | The status value of the condition. | Any Str | Recommended |
+| type | The type of the condition being reported. | Any Str | Recommended |
+| version | The API version of the Kubernetes resource | Any Str | Recommended |
 
 ### kyma.resource.status.state
 
@@ -40,7 +45,12 @@ The resource status state, metric value is 1 for the last scraped resource statu
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
+| group | The API group of the Kubernetes resource | Any Str | Recommended |
+| kind | The kind of the Kubernetes resource | Any Str | Recommended |
+| name | The name of the Kubernetes resource instance | Any Str | Recommended |
+| namespace | The Kubernetes namespace where the resource is located | Any Str | Recommended |
 | state | The state of the resource status. | Any Str | Recommended |
+| version | The API version of the Kubernetes resource | Any Str | Recommended |
 
 ## Resource Attributes
 

--- a/receiver/kymastatsreceiver/generated_package_test.go
+++ b/receiver/kymastatsreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package kymastatsreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/kymastatsreceiver/generated_package_test.go
+++ b/receiver/kymastatsreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package kymastatsreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/kymastatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_metrics.go
@@ -45,7 +45,7 @@ func (m *metricKymaResourceStatusConditions) init() {
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricKymaResourceStatusConditions) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, reasonAttributeValue string, statusAttributeValue string, typeAttributeValue string) {
+func (m *metricKymaResourceStatusConditions) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, groupAttributeValue string, kindAttributeValue string, nameAttributeValue string, namespaceAttributeValue string, reasonAttributeValue string, statusAttributeValue string, typeAttributeValue string, versionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -53,9 +53,14 @@ func (m *metricKymaResourceStatusConditions) recordDataPoint(start pcommon.Times
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntValue(val)
+	dp.Attributes().PutStr("group", groupAttributeValue)
+	dp.Attributes().PutStr("kind", kindAttributeValue)
+	dp.Attributes().PutStr("name", nameAttributeValue)
+	dp.Attributes().PutStr("namespace", namespaceAttributeValue)
 	dp.Attributes().PutStr("reason", reasonAttributeValue)
 	dp.Attributes().PutStr("status", statusAttributeValue)
 	dp.Attributes().PutStr("type", typeAttributeValue)
+	dp.Attributes().PutStr("version", versionAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -99,7 +104,7 @@ func (m *metricKymaResourceStatusState) init() {
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricKymaResourceStatusState) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stateAttributeValue string) {
+func (m *metricKymaResourceStatusState) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, groupAttributeValue string, kindAttributeValue string, nameAttributeValue string, namespaceAttributeValue string, stateAttributeValue string, versionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -107,7 +112,12 @@ func (m *metricKymaResourceStatusState) recordDataPoint(start pcommon.Timestamp,
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntValue(val)
+	dp.Attributes().PutStr("group", groupAttributeValue)
+	dp.Attributes().PutStr("kind", kindAttributeValue)
+	dp.Attributes().PutStr("name", nameAttributeValue)
+	dp.Attributes().PutStr("namespace", namespaceAttributeValue)
 	dp.Attributes().PutStr("state", stateAttributeValue)
+	dp.Attributes().PutStr("version", versionAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -311,13 +321,13 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 }
 
 // RecordKymaResourceStatusConditionsDataPoint adds a data point to kyma.resource.status.conditions metric.
-func (mb *MetricsBuilder) RecordKymaResourceStatusConditionsDataPoint(ts pcommon.Timestamp, val int64, reasonAttributeValue string, statusAttributeValue string, typeAttributeValue string) {
-	mb.metricKymaResourceStatusConditions.recordDataPoint(mb.startTime, ts, val, reasonAttributeValue, statusAttributeValue, typeAttributeValue)
+func (mb *MetricsBuilder) RecordKymaResourceStatusConditionsDataPoint(ts pcommon.Timestamp, val int64, groupAttributeValue string, kindAttributeValue string, nameAttributeValue string, namespaceAttributeValue string, reasonAttributeValue string, statusAttributeValue string, typeAttributeValue string, versionAttributeValue string) {
+	mb.metricKymaResourceStatusConditions.recordDataPoint(mb.startTime, ts, val, groupAttributeValue, kindAttributeValue, nameAttributeValue, namespaceAttributeValue, reasonAttributeValue, statusAttributeValue, typeAttributeValue, versionAttributeValue)
 }
 
 // RecordKymaResourceStatusStateDataPoint adds a data point to kyma.resource.status.state metric.
-func (mb *MetricsBuilder) RecordKymaResourceStatusStateDataPoint(ts pcommon.Timestamp, val int64, stateAttributeValue string) {
-	mb.metricKymaResourceStatusState.recordDataPoint(mb.startTime, ts, val, stateAttributeValue)
+func (mb *MetricsBuilder) RecordKymaResourceStatusStateDataPoint(ts pcommon.Timestamp, val int64, groupAttributeValue string, kindAttributeValue string, nameAttributeValue string, namespaceAttributeValue string, stateAttributeValue string, versionAttributeValue string) {
+	mb.metricKymaResourceStatusState.recordDataPoint(mb.startTime, ts, val, groupAttributeValue, kindAttributeValue, nameAttributeValue, namespaceAttributeValue, stateAttributeValue, versionAttributeValue)
 }
 
 // Reset resets metrics builder to its initial state. It should be used when external metrics source is restarted,

--- a/receiver/kymastatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_metrics.go
@@ -178,6 +178,21 @@ func WithStartTime(startTime pcommon.Timestamp) MetricBuilderOption {
 	})
 }
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...MetricBuilderOption) *MetricsBuilder {
+	if mbc.ResourceAttributes.K8sNamespaceName.Enabled {
+		settings.Logger.Warn("[WARNING] `k8s.namespace.name` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.")
+	}
+	if mbc.ResourceAttributes.K8sResourceGroup.Enabled {
+		settings.Logger.Warn("[WARNING] `k8s.resource.group` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.")
+	}
+	if mbc.ResourceAttributes.K8sResourceKind.Enabled {
+		settings.Logger.Warn("[WARNING] `k8s.resource.kind` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.")
+	}
+	if mbc.ResourceAttributes.K8sResourceName.Enabled {
+		settings.Logger.Warn("[WARNING] `k8s.resource.name` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.")
+	}
+	if mbc.ResourceAttributes.K8sResourceVersion.Enabled {
+		settings.Logger.Warn("[WARNING] `k8s.resource.version` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.")
+	}
 	mb := &MetricsBuilder{
 		config:                             mbc,
 		startTime:                          pcommon.NewTimestampFromTime(time.Now()),

--- a/receiver/kymastatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_metrics.go
@@ -178,21 +178,6 @@ func WithStartTime(startTime pcommon.Timestamp) MetricBuilderOption {
 	})
 }
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...MetricBuilderOption) *MetricsBuilder {
-	if mbc.ResourceAttributes.K8sNamespaceName.Enabled {
-		settings.Logger.Warn("[WARNING] `k8s.namespace.name` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.")
-	}
-	if mbc.ResourceAttributes.K8sResourceGroup.Enabled {
-		settings.Logger.Warn("[WARNING] `k8s.resource.group` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.")
-	}
-	if mbc.ResourceAttributes.K8sResourceKind.Enabled {
-		settings.Logger.Warn("[WARNING] `k8s.resource.kind` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.")
-	}
-	if mbc.ResourceAttributes.K8sResourceName.Enabled {
-		settings.Logger.Warn("[WARNING] `k8s.resource.name` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.")
-	}
-	if mbc.ResourceAttributes.K8sResourceVersion.Enabled {
-		settings.Logger.Warn("[WARNING] `k8s.resource.version` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.")
-	}
 	mb := &MetricsBuilder{
 		config:                             mbc,
 		startTime:                          pcommon.NewTimestampFromTime(time.Now()),

--- a/receiver/kymastatsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_metrics_test.go
@@ -62,26 +62,6 @@ func TestMetricsBuilder(t *testing.T) {
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 
 			expectedWarnings := 0
-			if tt.resAttrsSet == testDataSetDefault || tt.resAttrsSet == testDataSetAll {
-				assert.Equal(t, "[WARNING] `k8s.namespace.name` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if tt.resAttrsSet == testDataSetDefault || tt.resAttrsSet == testDataSetAll {
-				assert.Equal(t, "[WARNING] `k8s.resource.group` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if tt.resAttrsSet == testDataSetDefault || tt.resAttrsSet == testDataSetAll {
-				assert.Equal(t, "[WARNING] `k8s.resource.kind` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if tt.resAttrsSet == testDataSetDefault || tt.resAttrsSet == testDataSetAll {
-				assert.Equal(t, "[WARNING] `k8s.resource.name` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if tt.resAttrsSet == testDataSetDefault || tt.resAttrsSet == testDataSetAll {
-				assert.Equal(t, "[WARNING] `k8s.resource.version` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
 			assert.Equal(t, expectedWarnings, observedLogs.Len())
 
 			defaultMetricsCount := 0

--- a/receiver/kymastatsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_metrics_test.go
@@ -62,6 +62,26 @@ func TestMetricsBuilder(t *testing.T) {
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 
 			expectedWarnings := 0
+			if tt.resAttrsSet == testDataSetDefault || tt.resAttrsSet == testDataSetAll {
+				assert.Equal(t, "[WARNING] `k8s.namespace.name` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
+			if tt.resAttrsSet == testDataSetDefault || tt.resAttrsSet == testDataSetAll {
+				assert.Equal(t, "[WARNING] `k8s.resource.group` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
+			if tt.resAttrsSet == testDataSetDefault || tt.resAttrsSet == testDataSetAll {
+				assert.Equal(t, "[WARNING] `k8s.resource.kind` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
+			if tt.resAttrsSet == testDataSetDefault || tt.resAttrsSet == testDataSetAll {
+				assert.Equal(t, "[WARNING] `k8s.resource.name` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
+			if tt.resAttrsSet == testDataSetDefault || tt.resAttrsSet == testDataSetAll {
+				assert.Equal(t, "[WARNING] `k8s.resource.version` should not be enabled: This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute.", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
 			assert.Equal(t, expectedWarnings, observedLogs.Len())
 
 			defaultMetricsCount := 0

--- a/receiver/kymastatsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/kymastatsreceiver/internal/metadata/generated_metrics_test.go
@@ -69,11 +69,11 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordKymaResourceStatusConditionsDataPoint(ts, 1, "reason-val", "status-val", "type-val")
+			mb.RecordKymaResourceStatusConditionsDataPoint(ts, 1, "group-val", "kind-val", "name-val", "namespace-val", "reason-val", "status-val", "type-val", "version-val")
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordKymaResourceStatusStateDataPoint(ts, 1, "state-val")
+			mb.RecordKymaResourceStatusStateDataPoint(ts, 1, "group-val", "kind-val", "name-val", "namespace-val", "state-val", "version-val")
 
 			rb := mb.NewResourceBuilder()
 			rb.SetK8sNamespaceName("k8s.namespace.name-val")
@@ -115,7 +115,19 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("reason")
+					attrVal, ok := dp.Attributes().Get("group")
+					assert.True(t, ok)
+					assert.Equal(t, "group-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("kind")
+					assert.True(t, ok)
+					assert.Equal(t, "kind-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("name")
+					assert.True(t, ok)
+					assert.Equal(t, "name-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("namespace")
+					assert.True(t, ok)
+					assert.Equal(t, "namespace-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("reason")
 					assert.True(t, ok)
 					assert.Equal(t, "reason-val", attrVal.Str())
 					attrVal, ok = dp.Attributes().Get("status")
@@ -124,6 +136,9 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("type")
 					assert.True(t, ok)
 					assert.Equal(t, "type-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("version")
+					assert.True(t, ok)
+					assert.Equal(t, "version-val", attrVal.Str())
 				case "kyma.resource.status.state":
 					assert.False(t, validatedMetrics["kyma.resource.status.state"], "Found a duplicate in the metrics slice: kyma.resource.status.state")
 					validatedMetrics["kyma.resource.status.state"] = true
@@ -136,9 +151,24 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("state")
+					attrVal, ok := dp.Attributes().Get("group")
+					assert.True(t, ok)
+					assert.Equal(t, "group-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("kind")
+					assert.True(t, ok)
+					assert.Equal(t, "kind-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("name")
+					assert.True(t, ok)
+					assert.Equal(t, "name-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("namespace")
+					assert.True(t, ok)
+					assert.Equal(t, "namespace-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("state")
 					assert.True(t, ok)
 					assert.Equal(t, "state-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("version")
+					assert.True(t, ok)
+					assert.Equal(t, "version-val", attrVal.Str())
 				}
 			}
 		})

--- a/receiver/kymastatsreceiver/kyma_scraper.go
+++ b/receiver/kymastatsreceiver/kyma_scraper.go
@@ -88,7 +88,7 @@ func (ks *kymaScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 
 	for _, s := range stats {
 		if s.hasState {
-			ks.mb.RecordKymaResourceStatusStateDataPoint(now, int64(1), s.state)
+			ks.mb.RecordKymaResourceStatusStateDataPoint(now, int64(1), s.group, s.kind, s.name, s.namespace, s.state, s.version)
 		}
 
 		rb := ks.mb.NewResourceBuilder()
@@ -104,7 +104,7 @@ func (ks *kymaScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 
 		for _, c := range s.conditions {
 			val := conditionStatusToValue(c.status)
-			ks.mb.RecordKymaResourceStatusConditionsDataPoint(now, val, c.reason, c.status, c.condType)
+			ks.mb.RecordKymaResourceStatusConditionsDataPoint(now, val, s.group, s.kind, s.name, s.namespace, c.reason, c.status, c.condType, s.version)
 		}
 
 		ks.mb.EmitForResource(metadata.WithResource(rb.Emit()))

--- a/receiver/kymastatsreceiver/metadata.yaml
+++ b/receiver/kymastatsreceiver/metadata.yaml
@@ -18,32 +18,22 @@ resource_attributes:
     description: "The name of the namespace that the resource is running in"
     enabled: true
     type: string
-    warnings:
-      if_enabled: "This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute."
   k8s.resource.group:
     description: "The resource group"
     enabled: true
     type: string
-    warnings:
-      if_enabled: "This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute."
   k8s.resource.kind:
     description: "The resource kind"
     enabled: true
     type: string
-    warnings:
-      if_enabled: "This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute."
   k8s.resource.name:
     description: "The resource name"
     enabled: true
     type: string
-    warnings:
-      if_enabled: "This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute."
   k8s.resource.version:
     description: "The resource version"
     enabled: true
     type: string
-    warnings:
-      if_enabled: "This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute."
 attributes:
   group:
     description: The API group of the Kubernetes resource

--- a/receiver/kymastatsreceiver/metadata.yaml
+++ b/receiver/kymastatsreceiver/metadata.yaml
@@ -35,17 +35,32 @@ resource_attributes:
     enabled: true
     type: string
 attributes:
+  group:
+    description: The API group of the Kubernetes resource
+    type: string
+  kind:
+    description: The kind of the Kubernetes resource
+    type: string
+  name:
+    description: The name of the Kubernetes resource instance
+    type: string
+  namespace:
+    description: The Kubernetes namespace where the resource is located
+    type: string
   reason:
-    description: The reason of the resource condition status.
+    description: The reason for the resource condition status.
     type: string
   state:
     description: The state of the resource status.
     type: string
   status:
-    description: The status of the resource condition.
+    description: The status value of the condition.
     type: string
   type:
-    description: The type of the resource condition.
+    description: The type of the condition being reported.
+    type: string
+  version:
+    description: The API version of the Kubernetes resource
     type: string
 metrics:
   kyma.resource.status.conditions:
@@ -54,7 +69,7 @@ metrics:
     unit: "1"
     gauge:
       value_type: int
-    attributes: [ "reason", "status", "type" ]
+    attributes: [ "group", "kind", "name", "namespace","reason", "status", "type", "version" ]
     stability: alpha
   kyma.resource.status.state:
     enabled: true
@@ -62,5 +77,5 @@ metrics:
     unit: "1"
     gauge:
       value_type: int
-    attributes: [ "state" ]
+    attributes: [ "group", "kind", "name", "namespace","state","version" ]
     stability: alpha

--- a/receiver/kymastatsreceiver/metadata.yaml
+++ b/receiver/kymastatsreceiver/metadata.yaml
@@ -18,22 +18,32 @@ resource_attributes:
     description: "The name of the namespace that the resource is running in"
     enabled: true
     type: string
+    warnings:
+      if_enabled: "This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute."
   k8s.resource.group:
     description: "The resource group"
     enabled: true
     type: string
+    warnings:
+      if_enabled: "This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute."
   k8s.resource.kind:
     description: "The resource kind"
     enabled: true
     type: string
+    warnings:
+      if_enabled: "This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute."
   k8s.resource.name:
     description: "The resource name"
     enabled: true
     type: string
+    warnings:
+      if_enabled: "This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute."
   k8s.resource.version:
     description: "The resource version"
     enabled: true
     type: string
+    warnings:
+      if_enabled: "This resource attribute is deprecated and will be removed in a future release. The information is now available as a metric attribute."
 attributes:
   group:
     description: The API group of the Kubernetes resource

--- a/receiver/kymastatsreceiver/testdata/metrics.yaml
+++ b/receiver/kymastatsreceiver/testdata/metrics.yaml
@@ -4,18 +4,18 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: kyma-system
-        - key: k8s.resource.name
-          value:
-            stringValue: default
         - key: k8s.resource.group
           value:
             stringValue: operator.kyma-project.io
-        - key: k8s.resource.version
-          value:
-            stringValue: v1
         - key: k8s.resource.kind
           value:
             stringValue: telemetries
+        - key: k8s.resource.name
+          value:
+            stringValue: default
+        - key: k8s.resource.version
+          value:
+            stringValue: v1
 
     scopeMetrics:
       - metrics:
@@ -24,6 +24,18 @@ resourceMetrics:
               dataPoints:
                 - asInt: "1"
                   attributes:
+                    - key: group
+                      value:
+                        stringValue: operator.kyma-project.io
+                    - key: kind
+                      value:
+                        stringValue: telemetries
+                    - key: name
+                      value:
+                        stringValue: default
+                    - key: namespace
+                      value:
+                        stringValue: kyma-system
                     - key: reason
                       value:
                         stringValue: AllFine
@@ -33,6 +45,9 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: TelemetryHealthy
+                    - key: version
+                      value:
+                        stringValue: v1
             name: kyma.resource.status.conditions
             unit: "1"
           - description: The resource status state, metric value is 1 for the last scraped resource status state, including state as metric attribute.
@@ -40,9 +55,24 @@ resourceMetrics:
               dataPoints:
                 - asInt: "1"
                   attributes:
+                    - key: group
+                      value:
+                        stringValue: operator.kyma-project.io
+                    - key: kind
+                      value:
+                        stringValue: telemetries
+                    - key: name
+                      value:
+                        stringValue: default
+                    - key: namespace
+                      value:
+                        stringValue: kyma-system
                     - key: state
                       value:
                         stringValue: Ready
+                    - key: version
+                      value:
+                        stringValue: v1
             name: kyma.resource.status.state
             unit: "1"
         scope:
@@ -50,18 +80,18 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
-        - key: k8s.resource.name
-          value:
-            stringValue: pipe-1
         - key: k8s.resource.group
           value:
             stringValue: telemetry.kyma-project.io
-        - key: k8s.resource.version
-          value:
-            stringValue: v1alpha1
         - key: k8s.resource.kind
           value:
             stringValue: logpipelines
+        - key: k8s.resource.name
+          value:
+            stringValue: pipe-1
+        - key: k8s.resource.version
+          value:
+            stringValue: v1alpha1
 
     scopeMetrics:
       - metrics:
@@ -70,6 +100,18 @@ resourceMetrics:
               dataPoints:
                 - asInt: "1"
                   attributes:
+                    - key: group
+                      value:
+                        stringValue: telemetry.kyma-project.io
+                    - key: kind
+                      value:
+                        stringValue: logpipelines
+                    - key: name
+                      value:
+                        stringValue: pipe-1
+                    - key: namespace
+                      value:
+                        stringValue: ""
                     - key: reason
                       value:
                         stringValue: AgentReady
@@ -79,6 +121,9 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: AgentHealthy
+                    - key: version
+                      value:
+                        stringValue: v1alpha1
             name: kyma.resource.status.conditions
             unit: "1"
         scope:
@@ -89,15 +134,15 @@ resourceMetrics:
         - key: k8s.resource.group
           value:
             stringValue: telemetry.kyma-project.io
-        - key: k8s.resource.version
-          value:
-            stringValue: v1alpha1
         - key: k8s.resource.kind
           value:
             stringValue: logpipelines
         - key: k8s.resource.name
           value:
             stringValue: pipe-2
+        - key: k8s.resource.version
+          value:
+            stringValue: v1alpha1
     scopeMetrics:
       - metrics:
           - description: The resource status conditions. Possible metric values for condition status are 'True' => 1, 'False' => 0, and -1 for other status values.
@@ -105,6 +150,18 @@ resourceMetrics:
               dataPoints:
                 - asInt: "0"
                   attributes:
+                    - key: group
+                      value:
+                        stringValue: telemetry.kyma-project.io
+                    - key: kind
+                      value:
+                        stringValue: logpipelines
+                    - key: name
+                      value:
+                        stringValue: pipe-2
+                    - key: namespace
+                      value:
+                        stringValue: ""
                     - key: reason
                       value:
                         stringValue: AgentNotReady
@@ -114,6 +171,9 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: AgentHealthy
+                    - key: version
+                      value:
+                        stringValue: v1alpha1
             name: kyma.resource.status.conditions
             unit: "1"
         scope:


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- All the resource attributes of metrics `kyma.resource.status.conditions` and `kyma.resource.status.state` are redefined as regular metric attributes
- The receiver will scrape and emit metrics with both resource and metric attributes with the same values
- The resource attributes marked as deprecated 

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/3097

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [x] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
