### PR TITLE
fix: include unified OTLP gateway in istio noise filter

### DIFF
--- a/processor/istionoisefilter/internal/rules/common.go
+++ b/processor/istionoisefilter/internal/rules/common.go
@@ -12,6 +12,7 @@ var (
 		"telemetry-log-gateway":    {},
 		"telemetry-metric-gateway": {},
 		"telemetry-trace-gateway":  {},
+		"telemetry-otlp-gateway":   {},
 	}
 
 	telemetryModuleAgents = map[string]struct{}{
@@ -25,8 +26,8 @@ var (
 		telemetryModuleAgents,
 	)
 
-	regexTelemetryGatewayURL  = regexp.MustCompile(`^https?://telemetry-otlp-(logs|metrics|traces)\.kyma-system(\..*)?:(4317|4318).*`)
-	regexTelemetryGatewayHost = regexp.MustCompile(`^telemetry-otlp-(logs|metrics|traces)\.kyma-system.*`)
+	regexTelemetryGatewayURL  = regexp.MustCompile(`^https?://telemetry-otlp(-(logs|metrics|traces))?\.kyma-system(\..*)?:(4317|4318).*`)
+	regexTelemetryGatewayHost = regexp.MustCompile(`^telemetry-otlp(-(logs|metrics|traces))?\.kyma-system.*`)
 
 	healthzHostPrefix = "healthz."
 	healthzPath       = "/healthz/ready"

--- a/processor/istionoisefilter/istio_noise_filter_test.go
+++ b/processor/istionoisefilter/istio_noise_filter_test.go
@@ -99,6 +99,27 @@ func TestIstioNoiseFilter_Spans(t *testing.T) {
 			expectedSpanCount: 0,
 		},
 		{
+			name: "drops unified OTLP gateway span",
+			spanAttrs: []map[string]any{
+				{
+					"component":             "proxy",
+					"http.method":           "POST",
+					"http.url":              "https://telemetry-otlp.kyma-system.svc:4317/v1/traces",
+					"upstream_cluster.name": "outbound|4317|svc|telemetry-otlp.kyma-system.svc.cluster.local",
+				},
+			},
+			resourceAttrs:     map[string]any{},
+			expectedSpanCount: 0,
+		},
+		{
+			name: "drops OTLP gateway component span",
+			spanAttrs: []map[string]any{
+				{"component": "proxy", "istio.canonical_service": "telemetry-otlp-gateway"},
+			},
+			resourceAttrs:     map[string]any{"k8s.namespace.name": "kyma-system"},
+			expectedSpanCount: 0,
+		},
+		{
 			name: "drops if user agent is vm_promscrape",
 			spanAttrs: []map[string]any{
 				{
@@ -227,6 +248,30 @@ func TestIstioNoiseFilter_Logs(t *testing.T) {
 				},
 			},
 			resourceAttrs:    map[string]any{},
+			expectedLogCount: 0,
+		},
+		{
+			name: "drops log if server address is unified OTLP gateway",
+			logAttrs: []map[string]any{
+				{
+					"kyma.module":    "istio",
+					"server.address": "telemetry-otlp.kyma-system.svc:4317",
+				},
+			},
+			resourceAttrs:    map[string]any{},
+			expectedLogCount: 0,
+		},
+		{
+			name: "drops log if emitted by OTLP gateway",
+			logAttrs: []map[string]any{
+				{
+					"kyma.module": "istio",
+				},
+			},
+			resourceAttrs: map[string]any{
+				"k8s.namespace.name":  "kyma-system",
+				"k8s.deployment.name": "telemetry-otlp-gateway",
+			},
 			expectedLogCount: 0,
 		},
 		{
@@ -456,6 +501,13 @@ func TestIstioNoiseFilter_Metrics(t *testing.T) {
 			metricName:             "istio_summary",
 			dataPointAttrs:         []map[string]any{{"destination_workload": "telemetry-trace-gateway"}},
 			metricType:             pmetric.MetricTypeSummary,
+			expectedDataPointCount: 0,
+		},
+		{
+			name:                   "drops istio metric with destination_workload telemetry-otlp-gateway (Sum)",
+			metricName:             "istio_requests_total",
+			dataPointAttrs:         []map[string]any{{"destination_workload": "telemetry-otlp-gateway"}},
+			metricType:             pmetric.MetricTypeSum,
 			expectedDataPointCount: 0,
 		},
 		{


### PR DESCRIPTION
## Summary
- Adds `telemetry-otlp-gateway` to the known gateway components so its spans, access logs, and metrics are filtered as noise.
- Updates the gateway URL/host regex to also match the unified `telemetry-otlp.kyma-system` service endpoint (in addition to the existing per-signal `telemetry-otlp-(logs|metrics|traces)` services).
- Adds test coverage for all three signal types.

Fixes: https://github.com/kyma-project/telemetry-manager/issues/3525