### PR TITLE
chore: add notify-sbom job to release workflow for SLC-41 compliances

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -218,6 +218,30 @@ jobs:
         run: |
           echo "${{ needs.build-image.outputs.images }}"
 
+  upload-release-report:
+    needs:
+      - build-image
+    if: always() && !cancelled() && inputs.dry-run == false && needs.build-image.result == 'success'
+    permissions:
+      id-token: write
+      contents: read
+    uses: kyma-project/compliancy/.github/workflows/notify-release-report.yml@main
+    with:
+      release_version: ${{ inputs.name }}
+    secrets: inherit
+
+  notify-sbom:
+    needs: upload-release-report
+    if: always() && !cancelled() && inputs.dry-run == false && needs.upload-release-report.result == 'success'
+    permissions:
+      id-token: write
+      contents: read
+    uses: kyma-project/compliancy/.github/workflows/notify-component-sbom.yml@main
+    secrets: inherit
+    with:
+      component: kyma-project.io/module/opentelemetry-collector-components
+      version: ${{ inputs.name }}
+
   publish-release:
     permissions:
       contents: write # Required for creating the release
@@ -225,7 +249,9 @@ jobs:
     needs:
       - build-image
       - create-draft
-    if: inputs.dry-run == false
+      - upload-release-report
+      - notify-sbom
+    if: always() && !cancelled() && inputs.dry-run == false && needs.build-image.result == 'success' && needs.create-draft.result == 'success' && needs.upload-release-report.result == 'success' && needs.notify-sbom.result == 'success'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- add notify-sbom job to release workflow for SLC-41 compliance
- Upload relase-report as well

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
